### PR TITLE
chore(vuln): fix unsound-condition in publish workflow (SEC-162)

### DIFF
--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read  # minimal permissions for GITHUB_TOKEN
     name: Publish new release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2


### PR DESCRIPTION
Fixes zizmor unsound-condition finding. The `if:` condition mixed `${{ }}` with bare `||`, making the part after `}}` a string literal (always truthy). Removed `${{ }}` so the entire expression evaluates properly via implicit expression evaluation.